### PR TITLE
Hide passing tests from the reporter #17

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file.
 
+## [1.9.0]
+
+- [#17](https://github.com/estruyf/playwright-github-actions-reporter/issues/17): Added the ability to define which types of test results should be shown in the summary
+
 ## [1.8.0]
 
 - Added `⏭️` icon for skipped tests

--- a/README.md
+++ b/README.md
@@ -38,16 +38,18 @@ The reporter supports the following configuration options:
 | showAnnotations | Show annotations from tests | `true` |
 | showTags | Show tags from tests | `true` |
 | showError | Show error message in summary | `false` |
+| report | Define which types of test results should be shown in the summary | `['pass', 'skipped', 'fail', 'flaky']` |
 | quiet | Do not show any output in the console | `false` |
 
 To use these option, you can update the reporter configuration:
 
 ```ts
 import { defineConfig } from '@playwright/test';
+import type { GitHubActionOptions } from '@estruyf/github-actions-reporter';
 
 export default defineConfig({
   reporter: [
-    ['@estruyf/github-actions-reporter', {
+    ['@estruyf/github-actions-reporter', <GitHubActionOptions>{
       title: 'My custom title',
       useDetails: true,
       showError: true

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ The reporter supports the following configuration options:
 | showAnnotations | Show annotations from tests | `true` |
 | showTags | Show tags from tests | `true` |
 | showError | Show error message in summary | `false` |
-| report | Define which types of test results should be shown in the summary | `['pass', 'skipped', 'fail', 'flaky']` |
+| includeResults | Define which types of test results should be shown in the summary | `['pass', 'skipped', 'fail', 'flaky']` |
 | quiet | Do not show any output in the console | `false` |
 
 To use these option, you can update the reporter configuration:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@estruyf/github-actions-reporter",
-  "version": "1.8.0",
+  "version": "1.9.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@estruyf/github-actions-reporter",
-      "version": "1.8.0",
+      "version": "1.9.0",
       "license": "MIT",
       "dependencies": {
         "@actions/core": "^1.10.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@estruyf/github-actions-reporter",
-  "version": "1.8.0",
+  "version": "1.9.0",
   "description": "GitHub Actions reporter for Playwright",
   "main": "dist/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -7,7 +7,6 @@
     "build": "tsc",
     "watch": "tsc -w",
     "test": "NODE_ENV=development npx playwright test",
-    "test:local": "act -j testing -P ubuntu-latest=catthehacker/ubuntu:act-latest --container-architecture linux/amd64 --env GITHUB_STEP_SUMMARY='/dev/stdout'",
     "test:jest": "jest --coverage --coverageDirectory=../coverage"
   },
   "author": "Elio Struyf <elio@struyfconsulting.be>",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -20,7 +20,7 @@ const config: PlaywrightTestConfig<{}, {}> = {
         useDetails: false,
         showError: true,
         quiet: false,
-        report: ["fail", "flaky", "skipped"],
+        includeResults: ["fail", "flaky", "skipped"],
       },
     ],
     [
@@ -30,7 +30,7 @@ const config: PlaywrightTestConfig<{}, {}> = {
         useDetails: false,
         showError: true,
         quiet: false,
-        report: ["pass", "skipped"],
+        includeResults: ["pass", "skipped"],
       },
     ],
     [
@@ -39,7 +39,7 @@ const config: PlaywrightTestConfig<{}, {}> = {
         title: "Reporter (details: true, report: fail, flaky, skipped)",
         useDetails: true,
         quiet: true,
-        report: ["fail", "flaky", "skipped"],
+        includeResults: ["fail", "flaky", "skipped"],
       },
     ],
   ],

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,3 +1,4 @@
+import type { GitHubActionOptions } from "./src/models/GitHubActionOptions";
 import { PlaywrightTestConfig, defineConfig, devices } from "@playwright/test";
 
 const config: PlaywrightTestConfig<{}, {}> = {
@@ -14,14 +15,33 @@ const config: PlaywrightTestConfig<{}, {}> = {
     // ["list"],
     [
       "./src/index.ts",
-      {
-        title: "Reporter testing",
+      <GitHubActionOptions>{
+        title: "Reporter (details: false, report: fail, flaky, skipped)",
         useDetails: false,
         showError: true,
         quiet: false,
+        report: ["fail", "flaky", "skipped"],
       },
     ],
-    ["./src/index.ts", { useDetails: true, quiet: true }],
+    [
+      "./src/index.ts",
+      <GitHubActionOptions>{
+        title: "Reporter (details: false, report: pass, skipped)",
+        useDetails: false,
+        showError: true,
+        quiet: false,
+        report: ["pass", "skipped"],
+      },
+    ],
+    [
+      "./src/index.ts",
+      <GitHubActionOptions>{
+        title: "Reporter (details: true, report: fail, flaky, skipped)",
+        useDetails: true,
+        quiet: true,
+        report: ["fail", "flaky", "skipped"],
+      },
+    ],
   ],
   use: {
     actionTimeout: 0,

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,15 +8,7 @@ import type {
   TestResult,
 } from "@playwright/test/reporter";
 import { processResults } from "./utils/processResults";
-
-export interface GitHubActionOptions {
-  title?: string;
-  useDetails?: boolean;
-  showAnnotations: boolean;
-  showTags: boolean;
-  showError?: boolean;
-  quiet?: boolean;
-}
+import { GitHubActionOptions } from "./models";
 
 class GitHubAction implements Reporter {
   private suite: Suite | undefined;
@@ -37,6 +29,10 @@ class GitHubAction implements Reporter {
 
     if (typeof options.showTags === "undefined") {
       this.options.showTags = true;
+    }
+
+    if (typeof options.report === "undefined") {
+      this.options.report = ["fail", "flaky", "pass", "skipped"];
     }
 
     if (process.env.NODE_ENV === "development") {

--- a/src/index.ts
+++ b/src/index.ts
@@ -31,8 +31,8 @@ class GitHubAction implements Reporter {
       this.options.showTags = true;
     }
 
-    if (typeof options.report === "undefined") {
-      this.options.report = ["fail", "flaky", "pass", "skipped"];
+    if (typeof options.includeResults === "undefined") {
+      this.options.includeResults = ["fail", "flaky", "pass", "skipped"];
     }
 
     if (process.env.NODE_ENV === "development") {

--- a/src/models/DisplayLevel.ts
+++ b/src/models/DisplayLevel.ts
@@ -1,0 +1,1 @@
+export type DisplayLevel = "pass" | "skipped" | "fail" | "flaky";

--- a/src/models/GitHubActionOptions.ts
+++ b/src/models/GitHubActionOptions.ts
@@ -1,0 +1,11 @@
+import { DisplayLevel } from ".";
+
+export interface GitHubActionOptions {
+  title?: string;
+  useDetails?: boolean;
+  showAnnotations: boolean;
+  showTags: boolean;
+  showError?: boolean;
+  quiet?: boolean;
+  report?: DisplayLevel[];
+}

--- a/src/models/GitHubActionOptions.ts
+++ b/src/models/GitHubActionOptions.ts
@@ -7,5 +7,5 @@ export interface GitHubActionOptions {
   showTags: boolean;
   showError?: boolean;
   quiet?: boolean;
-  report?: DisplayLevel[];
+  includeResults?: DisplayLevel[];
 }

--- a/src/models/index.ts
+++ b/src/models/index.ts
@@ -1,0 +1,2 @@
+export * from "./DisplayLevel";
+export * from "./GitHubActionOptions";

--- a/src/utils/getHtmlTable.test.ts
+++ b/src/utils/getHtmlTable.test.ts
@@ -1,4 +1,12 @@
+import { DisplayLevel } from "../models";
 import { getHtmlTable } from "./getHtmlTable";
+
+const defaultDisplayLevel: DisplayLevel[] = [
+  "pass",
+  "fail",
+  "flaky",
+  "skipped",
+];
 
 describe("getHtmlTable", () => {
   it("should return the HTML table with error column", async () => {
@@ -46,7 +54,13 @@ describe("getHtmlTable", () => {
       },
     ];
 
-    const result = await getHtmlTable(tests, false, false, true);
+    const result = await getHtmlTable(
+      tests,
+      false,
+      false,
+      true,
+      defaultDisplayLevel
+    );
 
     const expected = `
 <br>
@@ -86,33 +100,59 @@ describe("getHtmlTable", () => {
 </table>
 `;
 
-    expect(result.trim()).toEqual(expected.trim());
+    expect(result?.trim()).toEqual(expected.trim());
   });
 
-  it("should return an empty HTML table if tests is empty (without error column)", async () => {
-    const result = await getHtmlTable([], false, false, false);
+  it("should return the HTML table with error column (excluding passed tests)", async () => {
+    const tests: any = [
+      {
+        title: "Test 1",
+        results: [
+          {
+            status: "passed",
+            duration: 1000,
+            retry: 0,
+            error: null,
+          },
+        ],
+        parent: {
+          title: "Parent Title",
+        },
+      },
+      {
+        title: "Test 2",
+        results: [
+          {
+            status: "failed",
+            duration: 2000,
+            retry: 1,
+            error: {
+              message: "Test failed",
+            },
+          },
+        ],
+        parent: null,
+      },
+      {
+        title: "Test 3",
+        results: [
+          {
+            status: "failed",
+            duration: null,
+            retry: null,
+            error: {
+              message: "Test failed",
+            },
+          },
+        ],
+      },
+    ];
 
-    const expected = `
-<br>
-<table role="table">
-<thead>
-<tr>
-<th>Test</th>
-<th>Status</th>
-<th>Duration</th>
-<th>Retries</th>
-</tr>
-</thead>
-<tbody>
-</tbody>
-</table>
-`;
-
-    expect(result.trim()).toEqual(expected.trim());
-  });
-
-  it("should return an empty HTML table if tests is empty (including error column)", async () => {
-    const result = await getHtmlTable([], false, false, true);
+    const result = await getHtmlTable(tests, false, false, true, [
+      "fail",
+      "flaky",
+      "skipped",
+    ]);
 
     const expected = `
 <br>
@@ -127,11 +167,49 @@ describe("getHtmlTable", () => {
 </tr>
 </thead>
 <tbody>
+<tr>
+<td>Test 2</td>
+<td>❌ Fail</td>
+<td>2s</td>
+<td>1</td>
+<td>Test failed</td>
+</tr>
+<tr>
+<td>Test 3</td>
+<td>❌ Fail</td>
+<td></td>
+<td></td>
+<td>Test failed</td>
+</tr>
 </tbody>
 </table>
 `;
 
-    expect(result.trim()).toEqual(expected.trim());
+    expect(result?.trim()).toEqual(expected.trim());
+  });
+
+  it("should not return a table when no tests are provided (without error column)", async () => {
+    const result = await getHtmlTable(
+      [],
+      false,
+      false,
+      false,
+      defaultDisplayLevel
+    );
+
+    expect(result).toBeUndefined();
+  });
+
+  it("should not return a table when no tests are provided (including error column)", async () => {
+    const result = await getHtmlTable(
+      [],
+      false,
+      false,
+      true,
+      defaultDisplayLevel
+    );
+
+    expect(result).toBeUndefined();
   });
 
   it("should return the HTML table with annotations row", async () => {
@@ -158,7 +236,13 @@ describe("getHtmlTable", () => {
       },
     ];
 
-    const result = await getHtmlTable(tests, true, false, false);
+    const result = await getHtmlTable(
+      tests,
+      true,
+      false,
+      false,
+      defaultDisplayLevel
+    );
 
     const expected = `
 <br>
@@ -184,7 +268,7 @@ describe("getHtmlTable", () => {
 </tbody>
 </table>`;
 
-    expect(result.trim()).toEqual(expected.trim());
+    expect(result?.trim()).toEqual(expected.trim());
   });
 
   it("should return the HTML table with annotations and tags columns", async () => {
@@ -226,7 +310,13 @@ describe("getHtmlTable", () => {
       },
     ];
 
-    const result = await getHtmlTable(tests, true, true, true);
+    const result = await getHtmlTable(
+      tests,
+      true,
+      true,
+      true,
+      defaultDisplayLevel
+    );
 
     const expected = `
 <br>
@@ -264,6 +354,6 @@ describe("getHtmlTable", () => {
 </tbody>
 </table>`;
 
-    expect(result.trim()).toEqual(expected.trim());
+    expect(result?.trim()).toEqual(expected.trim());
   });
 });

--- a/src/utils/getSuiteStatusIcon.test.ts
+++ b/src/utils/getSuiteStatusIcon.test.ts
@@ -1,0 +1,58 @@
+import { TestCase } from "@playwright/test/reporter";
+import { getSuiteStatusIcon } from "./getSuiteStatusIcon";
+
+describe("getSuiteStatusIcon", () => {
+  it("should return ✅ if all tests have passed", () => {
+    const tests = [
+      { results: [{ status: "passed" }], outcome: () => "expected" },
+    ] as TestCase[];
+
+    const result = getSuiteStatusIcon(tests);
+
+    expect(result).toBe("✅");
+  });
+
+  it("should return ⏭️ if any test has been skipped", () => {
+    const tests = [
+      { results: [{ status: "skipped" }], outcome: () => "expected" },
+    ] as TestCase[];
+
+    const result = getSuiteStatusIcon(tests);
+
+    expect(result).toBe("✅");
+  });
+
+  it("should return ❌ if any test has failed, interrupted, or timed out", () => {
+    const tests = [
+      { results: [{ status: "failed" }], outcome: () => "expected" },
+    ] as TestCase[];
+
+    const result = getSuiteStatusIcon(tests);
+
+    expect(result).toBe("❌");
+  });
+
+  it("should return ❌ if no tests", () => {
+    const result = getSuiteStatusIcon(undefined as any);
+
+    expect(result).toBe("❌");
+  });
+
+  it("should return ❌ if there is no test status", () => {
+    const tests = [
+      { results: [{}], outcome: () => "unexpected" },
+    ] as TestCase[];
+
+    const result = getSuiteStatusIcon(tests);
+
+    expect(result).toBe("❌");
+  });
+
+  it("should return ⚠️ if any test is flaky", () => {
+    const tests = [{ results: [{}], outcome: () => "flaky" }] as TestCase[];
+
+    const result = getSuiteStatusIcon(tests);
+
+    expect(result).toBe("⚠️");
+  });
+});

--- a/src/utils/getSuiteStatusIcon.ts
+++ b/src/utils/getSuiteStatusIcon.ts
@@ -1,0 +1,30 @@
+import { TestCase } from "@playwright/test/reporter";
+import { getTestOutcome } from "./getTestOutcome";
+
+export const getSuiteStatusIcon = (tests: TestCase[]) => {
+  if (!tests || tests.length === 0) {
+    return "❌";
+  }
+
+  const testOutcomes = tests.map((test) => {
+    const lastResult = test.results[test.results.length - 1];
+    const outcome = test.outcome();
+    if (outcome === "flaky") {
+      return "flaky";
+    }
+
+    return getTestOutcome(test, lastResult);
+  });
+
+  if (
+    testOutcomes.includes("failed") ||
+    testOutcomes.includes("interrupted") ||
+    testOutcomes.includes("timedOut")
+  ) {
+    return "❌";
+  } else if (testOutcomes.includes("flaky")) {
+    return "⚠️";
+  }
+
+  return "✅";
+};

--- a/src/utils/getTableRows.test.ts
+++ b/src/utils/getTableRows.test.ts
@@ -1,3 +1,4 @@
+import { DisplayLevel } from "../models";
 import { getTableRows } from "./getTableRows";
 
 const tableHeaders = [
@@ -17,6 +18,13 @@ const tableHeaders = [
     data: "Retries",
     header: true,
   },
+];
+
+const defaultDisplayLevel: DisplayLevel[] = [
+  "pass",
+  "fail",
+  "flaky",
+  "skipped",
 ];
 
 describe("getTableRows", () => {
@@ -52,7 +60,13 @@ describe("getTableRows", () => {
       },
     ];
 
-    const result = await getTableRows(tests, false, false, true);
+    const result = await getTableRows(
+      tests,
+      false,
+      false,
+      true,
+      defaultDisplayLevel
+    );
     const clonedTableHeaders = Object.assign([], tableHeaders);
     clonedTableHeaders.push({ data: "Error", header: true });
 
@@ -65,6 +79,60 @@ describe("getTableRows", () => {
         { data: "", header: false },
         { data: "", header: false },
       ],
+      [
+        { data: "Test 2", header: false },
+        { data: "❌ Fail", header: false },
+        { data: "2s", header: false },
+        { data: "1", header: false },
+        { data: "Test failed", header: false },
+      ],
+    ];
+
+    expect(result).toEqual(expected);
+  });
+
+  it("should return the table rows with headers and data (excluding passed tests)", async () => {
+    const tests: any = [
+      {
+        title: "Test 1",
+        results: [
+          {
+            status: "passed",
+            duration: 1000,
+            retry: 0,
+            error: null,
+          },
+        ],
+        parent: {
+          title: "Parent Title",
+        },
+      },
+      {
+        title: "Test 2",
+        results: [
+          {
+            status: "failed",
+            duration: 2000,
+            retry: 1,
+            error: {
+              message: "Test failed",
+            },
+          },
+        ],
+        parent: null,
+      },
+    ];
+
+    const result = await getTableRows(tests, false, false, true, [
+      "fail",
+      "flaky",
+      "skipped",
+    ]);
+    const clonedTableHeaders = Object.assign([], tableHeaders);
+    clonedTableHeaders.push({ data: "Error", header: true });
+
+    const expected = [
+      clonedTableHeaders,
       [
         { data: "Test 2", header: false },
         { data: "❌ Fail", header: false },
@@ -105,7 +173,13 @@ describe("getTableRows", () => {
       },
     ];
 
-    const result = await getTableRows(tests, false, false, false);
+    const result = await getTableRows(
+      tests,
+      false,
+      false,
+      false,
+      defaultDisplayLevel
+    );
 
     expect(result).toEqual([
       tableHeaders,
@@ -125,17 +199,29 @@ describe("getTableRows", () => {
   });
 
   it("should return an empty array if tests is empty (without error header)", async () => {
-    const result = await getTableRows([], false, false, false);
+    const result = await getTableRows(
+      [],
+      false,
+      false,
+      false,
+      defaultDisplayLevel
+    );
 
-    expect(result).toEqual([tableHeaders]);
+    expect(result).toEqual([]);
   });
 
   it("should return an empty array if tests is empty (including error header)", async () => {
-    const result = await getTableRows([], false, false, true);
+    const result = await getTableRows(
+      [],
+      false,
+      false,
+      true,
+      defaultDisplayLevel
+    );
     const clonedTableHeaders = Object.assign([], tableHeaders);
     clonedTableHeaders.push({ data: "Error", header: true });
 
-    expect(result).toEqual([clonedTableHeaders]);
+    expect(result).toEqual([]);
   });
 
   it("should return the table rows with annotations", async () => {
@@ -171,7 +257,13 @@ describe("getTableRows", () => {
       },
     ];
 
-    const result = await getTableRows(tests, true, false, false);
+    const result = await getTableRows(
+      tests,
+      true,
+      false,
+      false,
+      defaultDisplayLevel
+    );
 
     const expected = [
       tableHeaders,
@@ -240,7 +332,13 @@ describe("getTableRows", () => {
       },
     ];
 
-    const result = await getTableRows(tests, true, true, true);
+    const result = await getTableRows(
+      tests,
+      true,
+      true,
+      true,
+      defaultDisplayLevel
+    );
 
     const clonedTableHeaders = Object.assign([], tableHeaders);
     clonedTableHeaders.push({ data: "Tags", header: true });

--- a/src/utils/getTestStatus.test.ts
+++ b/src/utils/getTestStatus.test.ts
@@ -1,7 +1,7 @@
 import { getTestStatus } from "./getTestStatus";
 
 describe("getTestStatus", () => {
-  it("should return '⚠️ Flaky' when test status is 'passed' and result retry is greater than 0", () => {
+  it("should return 'Flaky' when test status is 'passed' and result retry is greater than 0", () => {
     const test: any = {
       outcome: () => "expected",
     };
@@ -12,10 +12,10 @@ describe("getTestStatus", () => {
 
     const status = getTestStatus(test, result);
 
-    expect(status).toBe("⚠️ Flaky");
+    expect(status).toBe("Flaky");
   });
 
-  it("should return '✅ Pass' when test status is 'passed' and result retry is 0", () => {
+  it("should return 'Pass' when test status is 'passed' and result retry is 0", () => {
     const test: any = {
       outcome: () => "expected",
     };
@@ -26,10 +26,10 @@ describe("getTestStatus", () => {
 
     const status = getTestStatus(test, result);
 
-    expect(status).toBe("✅ Pass");
+    expect(status).toBe("Pass");
   });
 
-  it("should return '⏭️ Skipped' when test status is 'skipped'", () => {
+  it("should return 'Skipped' when test status is 'skipped'", () => {
     const test: any = {
       outcome: () => "expected",
     };
@@ -40,10 +40,10 @@ describe("getTestStatus", () => {
 
     const status = getTestStatus(test, result);
 
-    expect(status).toBe("⏭️ Skipped");
+    expect(status).toBe("Skipped");
   });
 
-  it("should return '❌ Fail' when test status is not 'passed' or 'skipped'", () => {
+  it("should return 'Fail' when test status is not 'passed' or 'skipped'", () => {
     const test: any = {
       outcome: () => "unexpected",
     };
@@ -54,10 +54,10 @@ describe("getTestStatus", () => {
 
     const status = getTestStatus(test, result);
 
-    expect(status).toBe("❌ Fail");
+    expect(status).toBe("Fail");
   });
 
-  it("should return '❌ Fail' when no test status is provided", () => {
+  it("should return 'Fail' when no test status is provided", () => {
     const test: any = {
       outcome: () => "unexpected",
     };
@@ -67,6 +67,6 @@ describe("getTestStatus", () => {
 
     const status = getTestStatus(test, result);
 
-    expect(status).toBe("❌ Fail");
+    expect(status).toBe("Fail");
   });
 });

--- a/src/utils/getTestStatus.ts
+++ b/src/utils/getTestStatus.ts
@@ -1,19 +1,22 @@
 import { TestCase, TestResult } from "@playwright/test/reporter";
 import { getTestOutcome } from "./getTestOutcome";
 
-export const getTestStatus = (test: TestCase, result: TestResult) => {
+export const getTestStatus = (
+  test: TestCase,
+  result: TestResult
+): "Flaky" | "Pass" | "Skipped" | "Fail" | string => {
   let value = "";
 
   let status = getTestOutcome(test, result);
 
   if (status === "passed" && result.retry > 0) {
-    value = `⚠️ Flaky`;
+    value = `Flaky`;
   } else if (status === "passed") {
-    value = "✅ Pass";
+    value = "Pass";
   } else if (status === "skipped") {
-    value = `⏭️ Skipped`;
+    value = `Skipped`;
   } else {
-    value = "❌ Fail";
+    value = "Fail";
   }
 
   return value;

--- a/src/utils/getTestStatusIcon.test.ts
+++ b/src/utils/getTestStatusIcon.test.ts
@@ -1,58 +1,72 @@
-import { TestCase } from "@playwright/test/reporter";
 import { getTestStatusIcon } from "./getTestStatusIcon";
 
 describe("getTestStatusIcon", () => {
-  it("should return ✅ if all tests have passed", () => {
-    const tests = [
-      { results: [{ status: "passed" }], outcome: () => "expected" },
-    ] as TestCase[];
+  it("should return '⚠️' when test status is 'passed' and result retry is greater than 0", () => {
+    const test: any = {
+      outcome: () => "expected",
+    };
+    const result: any = {
+      retry: 1,
+      status: "passed",
+    };
 
-    const result = getTestStatusIcon(tests);
+    const status = getTestStatusIcon(test, result);
 
-    expect(result).toBe("✅");
+    expect(status).toBe("⚠️");
   });
 
-  it("should return ⏭️ if any test has been skipped", () => {
-    const tests = [
-      { results: [{ status: "skipped" }], outcome: () => "expected" },
-    ] as TestCase[];
+  it("should return '✅' when test status is 'passed' and result retry is 0", () => {
+    const test: any = {
+      outcome: () => "expected",
+    };
+    const result: any = {
+      retry: 0,
+      status: "passed",
+    };
 
-    const result = getTestStatusIcon(tests);
+    const status = getTestStatusIcon(test, result);
 
-    expect(result).toBe("✅");
+    expect(status).toBe("✅");
   });
 
-  it("should return ❌ if any test has failed, interrupted, or timed out", () => {
-    const tests = [
-      { results: [{ status: "failed" }], outcome: () => "expected" },
-    ] as TestCase[];
+  it("should return '⏭️' when test status is 'skipped'", () => {
+    const test: any = {
+      outcome: () => "expected",
+    };
+    const result: any = {
+      retry: 1,
+      status: "skipped",
+    };
 
-    const result = getTestStatusIcon(tests);
+    const status = getTestStatusIcon(test, result);
 
-    expect(result).toBe("❌");
+    expect(status).toBe("⏭️");
   });
 
-  it("should return ❌ if no tests", () => {
-    const result = getTestStatusIcon(undefined as any);
+  it("should return '❌' when test status is not 'passed' or 'skipped'", () => {
+    const test: any = {
+      outcome: () => "unexpected",
+    };
+    const result: any = {
+      retry: 1,
+      status: "failed",
+    };
 
-    expect(result).toBe("❌");
+    const status = getTestStatusIcon(test, result);
+
+    expect(status).toBe("❌");
   });
 
-  it("should return ❌ if there is no test status", () => {
-    const tests = [
-      { results: [{}], outcome: () => "unexpected" },
-    ] as TestCase[];
+  it("should return '❌' when no test status is provided", () => {
+    const test: any = {
+      outcome: () => "unexpected",
+    };
+    const result: any = {
+      retry: 1,
+    };
 
-    const result = getTestStatusIcon(tests);
+    const status = getTestStatusIcon(test, result);
 
-    expect(result).toBe("❌");
-  });
-
-  it("should return ⚠️ if any test is flaky", () => {
-    const tests = [{ results: [{}], outcome: () => "flaky" }] as TestCase[];
-
-    const result = getTestStatusIcon(tests);
-
-    expect(result).toBe("⚠️");
+    expect(status).toBe("❌");
   });
 });

--- a/src/utils/getTestStatusIcon.ts
+++ b/src/utils/getTestStatusIcon.ts
@@ -1,30 +1,18 @@
-import { TestCase } from "@playwright/test/reporter";
-import { getTestOutcome } from "./getTestOutcome";
+import { TestCase, TestResult } from "@playwright/test/reporter";
+import { getTestStatus } from "./getTestStatus";
 
-export const getTestStatusIcon = (tests: TestCase[]) => {
-  if (!tests || tests.length === 0) {
-    return "❌";
+export const getTestStatusIcon = (test: TestCase, result: TestResult) => {
+  let value = getTestStatus(test, result);
+
+  if (value === "Flaky") {
+    value = `⚠️`;
+  } else if (value === "Pass") {
+    value = "✅";
+  } else if (value === "Skipped") {
+    value = `⏭️`;
+  } else if (value === "Fail") {
+    value = "❌";
   }
 
-  const testOutcomes = tests.map((test) => {
-    const lastResult = test.results[test.results.length - 1];
-    const outcome = test.outcome();
-    if (outcome === "flaky") {
-      return "flaky";
-    }
-
-    return getTestOutcome(test, lastResult);
-  });
-
-  if (
-    testOutcomes.includes("failed") ||
-    testOutcomes.includes("interrupted") ||
-    testOutcomes.includes("timedOut")
-  ) {
-    return "❌";
-  } else if (testOutcomes.includes("flaky")) {
-    return "⚠️";
-  }
-
-  return "✅";
+  return value;
 };

--- a/src/utils/processResults.ts
+++ b/src/utils/processResults.ts
@@ -3,14 +3,14 @@ import { SUMMARY_ENV_VAR } from "@actions/core/lib/summary";
 import { Suite } from "@playwright/test/reporter";
 import { existsSync, unlinkSync, writeFileSync } from "fs";
 import { basename, join } from "path";
-import { GitHubActionOptions } from "..";
 import { getHtmlTable } from "./getHtmlTable";
-import { getTestStatusIcon } from "./getTestStatusIcon";
+import { getSuiteStatusIcon } from "./getSuiteStatusIcon";
 import { getTableRows } from "./getTableRows";
 import { getSummaryTitle } from "./getSummaryTitle";
 import { getSummaryDetails } from "./getSummaryDetails";
 import { getTestsPerFile } from "./getTestsPerFile";
 import { getTestHeading } from "./getTestHeading";
+import { DisplayLevel, GitHubActionOptions } from "../models";
 
 export const processResults = async (
   suite: Suite | undefined,
@@ -55,26 +55,34 @@ export const processResults = async (
             tests[filePath],
             options.showAnnotations,
             options.showTags,
-            !!options.showError
+            !!options.showError,
+            options.report as DisplayLevel[]
           );
 
+          if (!content) {
+            continue;
+          }
+
           // Check if there are any failed tests
-          const testStatusIcon = getTestStatusIcon(tests[filePath]);
+          const testStatusIcon = getSuiteStatusIcon(tests[filePath]);
 
           summary.addDetails(
             `${testStatusIcon} ${getTestHeading(fileName, os, project)}`,
             content
           );
         } else {
-          summary.addHeading(getTestHeading(fileName, os, project), 2);
-
           const tableRows = await getTableRows(
             tests[filePath],
             options.showAnnotations,
             options.showTags,
-            !!options.showError
+            !!options.showError,
+            options.report as DisplayLevel[]
           );
-          summary.addTable(tableRows);
+
+          if (tableRows.length !== 0) {
+            summary.addHeading(getTestHeading(fileName, os, project), 2);
+            summary.addTable(tableRows);
+          }
         }
       }
     }

--- a/src/utils/processResults.ts
+++ b/src/utils/processResults.ts
@@ -56,7 +56,7 @@ export const processResults = async (
             options.showAnnotations,
             options.showTags,
             !!options.showError,
-            options.report as DisplayLevel[]
+            options.includeResults as DisplayLevel[]
           );
 
           if (!content) {
@@ -76,7 +76,7 @@ export const processResults = async (
             options.showAnnotations,
             options.showTags,
             !!options.showError,
-            options.report as DisplayLevel[]
+            options.includeResults as DisplayLevel[]
           );
 
           if (tableRows.length !== 0) {


### PR DESCRIPTION
Release version 1.9.0

[#17](https://github.com/estruyf/playwright-github-actions-reporter/issues/17): Added the ability to define which types of test results should be shown in the summary