### PR TITLE
chore: use public repository metadata

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+ssh://git@github.com/estruyf/playwright-github-actions-reporter.git"
+    "url": "git+https://github.com/estruyf/playwright-github-actions-reporter.git"
   },
   "keywords": [
     "playwright",


### PR DESCRIPTION
## Summary
- replace the SSH repository metadata with a public HTTPS Git URL
- keep npm package metadata usable for tooling without requiring GitHub SSH access

## Verification
- `node -e "const p=require('./package.json'); console.log(p.name, p.version, p.repository.url)"`
- `npm ci --ignore-scripts --no-audit --no-fund`
- `npm run build`
- `npm run test:jest -- --runInBand`
- `npm pack --dry-run --ignore-scripts --json .`
- `git diff --check`
